### PR TITLE
Support Serilog 2.0-style level formatting

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  "projects": [ "src", "test" ],
+  "projects": [ "src", "test", "sample" ],
   "sdk": {
     "version": "1.0.0-preview2-003121"
   }

--- a/sample/LiterateConsoleDemo/LiterateConsoleDemo.xproj
+++ b/sample/LiterateConsoleDemo/LiterateConsoleDemo.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>1ddbf7e3-2ce3-40e0-9238-9b1ed9efb90b</ProjectGuid>
+    <RootNamespace>LiterateConsoleDemo</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/sample/LiterateConsoleDemo/Program.cs
+++ b/sample/LiterateConsoleDemo/Program.cs
@@ -1,0 +1,21 @@
+﻿using Serilog;
+using System;
+using System.Threading;
+
+namespace LiterateConsoleDemo
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.LiterateConsole()
+                .CreateLogger();
+
+            Log.Information("Hello {Name} from thread {ThreadId}", Environment.GetEnvironmentVariable("USERNAME"),
+                Thread.CurrentThread.ManagedThreadId);
+
+            Log.CloseAndFlush();
+        }
+    }
+}

--- a/sample/LiterateConsoleDemo/Properties/AssemblyInfo.cs
+++ b/sample/LiterateConsoleDemo/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LiterateConsoleDemo")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1ddbf7e3-2ce3-40e0-9238-9b1ed9efb90b")]

--- a/sample/LiterateConsoleDemo/project.json
+++ b/sample/LiterateConsoleDemo/project.json
@@ -1,0 +1,20 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0"
+    },
+    "Serilog.Sinks.Literate": {"target": "project"}
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/serilog-sinks-literate.sln
+++ b/serilog-sinks-literate.sln
@@ -20,6 +20,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{5AB86B48-9
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Serilog.Sinks.Literate.Tests", "test\Serilog.Sinks.Literate.Tests\Serilog.Sinks.Literate.Tests.xproj", "{3C2D8E01-5580-426A-BDD9-EC59CD98E618}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{84987FC9-EF9C-4E70-BD0B-3BA9605C922A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "LiterateConsoleDemo", "sample\LiterateConsoleDemo\LiterateConsoleDemo.xproj", "{1DDBF7E3-2CE3-40E0-9238-9B1ED9EFB90B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +38,10 @@ Global
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DDBF7E3-2CE3-40E0-9238-9B1ED9EFB90B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DDBF7E3-2CE3-40E0-9238-9B1ED9EFB90B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DDBF7E3-2CE3-40E0-9238-9B1ED9EFB90B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DDBF7E3-2CE3-40E0-9238-9B1ED9EFB90B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -41,5 +49,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{D8A74F4C-981B-41F1-B807-FE08DFCC06D4} = {1036AE72-6B5B-40F3-A838-D6B3628B20C7}
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618} = {5AB86B48-9C2B-47EC-9F51-3356B196C185}
+		{1DDBF7E3-2CE3-40E0-9238-9B1ED9EFB90B} = {84987FC9-EF9C-4E70-BD0B-3BA9605C922A}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Sinks.Literate/LoggerConfigurationLiterateExtensions.cs
+++ b/src/Serilog.Sinks.Literate/LoggerConfigurationLiterateExtensions.cs
@@ -24,7 +24,7 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationLiterateExtensions
     {
-        const string DefaultOutputTemplate = "[{Timestamp:HH:mm:ss} {Level}] {Message}{NewLine}{Exception}";
+        const string DefaultOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message}{NewLine}{Exception}";
 
         /// <summary>
         /// Writes log events to <see cref="System.Console"/>, using pretty printing to display inline event data.

--- a/src/Serilog.Sinks.Literate/Sinks/Literate/LiterateConsoleSink.cs
+++ b/src/Serilog.Sinks.Literate/Sinks/Literate/LiterateConsoleSink.cs
@@ -47,24 +47,22 @@ namespace Serilog.Sinks.Literate
 
         class LevelFormat
         {
-            public LevelFormat(string description, ConsoleColor color)
+            public LevelFormat(ConsoleColor color)
             {
-                Description = description;
                 Color = color;
             }
 
-            public string Description { get; }
             public ConsoleColor Color { get; }
         }
 
         readonly IDictionary<LogEventLevel, LevelFormat> _levels = new Dictionary<LogEventLevel, LevelFormat>
         {
-            { LogEventLevel.Verbose, new LevelFormat("VRB", VerboseLevel) },
-            { LogEventLevel.Debug, new LevelFormat("DBG", DebugLevel) },
-            { LogEventLevel.Information, new LevelFormat("INF", InformationLevel) },
-            { LogEventLevel.Warning, new LevelFormat("WRN", WarningLevel) },
-            { LogEventLevel.Error, new LevelFormat("ERR", ErrorLevel) },
-            { LogEventLevel.Fatal, new LevelFormat("FTL", FatalLevel) },
+            { LogEventLevel.Verbose, new LevelFormat(VerboseLevel) },
+            { LogEventLevel.Debug, new LevelFormat(DebugLevel) },
+            { LogEventLevel.Information, new LevelFormat(InformationLevel) },
+            { LogEventLevel.Warning, new LevelFormat(WarningLevel) },
+            { LogEventLevel.Error, new LevelFormat(ErrorLevel) },
+            { LogEventLevel.Fatal, new LevelFormat(FatalLevel) },
         };
 
         readonly IFormatProvider _formatProvider;
@@ -98,7 +96,7 @@ namespace Serilog.Sinks.Literate
                         else switch (propertyToken.PropertyName)
                         {
                             case OutputProperties.LevelPropertyName:
-                                RenderLevelToken(logEvent.Level);
+                                RenderLevelToken(logEvent.Level, outputToken, outputProperties);
                                 break;
                             case OutputProperties.MessagePropertyName:
                                 RenderMessageToken(logEvent);
@@ -166,7 +164,7 @@ namespace Serilog.Sinks.Literate
             }
         }
 
-        void RenderLevelToken(LogEventLevel level)
+        void RenderLevelToken(LogEventLevel level, MessageTemplateToken token, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
         {
             LevelFormat format;
             if (!_levels.TryGetValue(level, out format))
@@ -180,7 +178,7 @@ namespace Serilog.Sinks.Literate
                 Console.ForegroundColor = ConsoleColor.White;
             }
 
-            Console.Write(format.Description);
+            token.Render(properties, Console.Out);
             Console.ResetColor();
         }
 


### PR DESCRIPTION
Defaults the output template to use `:u3` (three-char uppercase) level names to match the earlier version.

Includes a minimal sample console app for easier development.
